### PR TITLE
fix github action permission error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
previous github action was throwing a 403 error, it's fixed now. as seen here on this test run in my fork: https://github.com/hellno/fcblock/releases.

i've downloaded and installed the release from this action and it runs in my Chrome browser