### PR TITLE
Port extension as a firefox addon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       
-    - name: Create zip
+    - name: Create Chrome zip
       run: |
         zip -r fc-tweak.zip \
+          manifest.json \
+          content.js \
+          popup.html \
+          popup.js \
+          styles.css \
+          icons/
+
+    - name: Create Firefox zip
+      run: |
+        zip -r fc-tweak-firefox.zip \
           manifest.json \
           content.js \
           popup.html \
@@ -27,5 +37,7 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        files: fc-tweak.zip
+        files: |
+          fc-tweak.zip
+          fc-tweak-firefox.zip
         generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FC Tweak
 
-A Chrome extension to tweak your Farcaster experience. Works with Chrome, Arc, and other Chromium browsers.
+A browser extension to tweak your Farcaster experience. Works with Chrome, Arc, and other Chromium browsers, as well as Firefox.
 
 ## Features
 
@@ -23,12 +23,23 @@ https://chromewebstore.google.com/detail/fc-tweak/kbponcgllocjppgoolliblbalfbmnj
 6. Enable "Developer mode" in the top right corner
 7. Click "Load unpacked" and select the extracted folder
 
-### From Source
+### From Source (Chrome / Chromium)
 
 1. Clone this repository
 2. Open `chrome://extensions/`
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select this folder
+
+### Firefox
+
+Load it temporarily for testing:
+
+1. Clone this repository (or download and extract `fc-tweak-firefox.zip` from a [Release](https://github.com/lyoshenka/fctweak/releases))
+2. Open `about:debugging#/runtime/this-firefox`
+3. Click "Load Temporary Add-on…"
+4. Select the `manifest.json` file in this folder
+
+(Temporary add-ons are removed when Firefox restarts. A permanently-installable, signed version will be available on [addons.mozilla.org](https://addons.mozilla.org) once published.)
 
 ## Permissions
 

--- a/content.js
+++ b/content.js
@@ -1,10 +1,13 @@
 // FC Tweak Content Script
 
+// Cross-browser namespace: Firefox exposes promise-based `browser`, Chrome uses `chrome`.
+const api = globalThis.browser ?? globalThis.chrome;
+
 let isBlocking = true; // Default state
 let originalContent = null; // Store original content when blocking is disabled
 
 // Check initial state from storage
-chrome.storage.sync.get(["fcBlockEnabled"], (result) => {
+api.storage.sync.get(["fcBlockEnabled"]).then((result) => {
   isBlocking = result.fcBlockEnabled !== false; // Default to true
   if (isBlocking) {
     document.body.classList.add("fc-block-enabled");
@@ -13,7 +16,7 @@ chrome.storage.sync.get(["fcBlockEnabled"], (result) => {
 });
 
 // Listen for messages from popup
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+api.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "toggleBlock") {
     console.log("Received toggle message:", request.enabled);
     isBlocking = request.enabled;

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,15 @@
   "version": "1.0.0",
   "description": "Tweak your Farcaster experience - block the feed and notifications to stay focused.",
   "permissions": ["activeTab", "storage"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "fctweak@neynar.com",
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
   "content_scripts": [
     {
       "matches": ["https://farcaster.xyz/*"],

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,8 @@
 // Popup script for FC Tweak extension
 
+// Cross-browser namespace: Firefox exposes promise-based `browser`, Chrome uses `chrome`.
+const api = globalThis.browser ?? globalThis.chrome;
+
 document.addEventListener("DOMContentLoaded", async () => {
   const toggle = document.getElementById("toggle");
   const statusText = document.getElementById("status");
@@ -7,7 +10,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let isCountingDown = false;
 
   // Load current state
-  const result = await chrome.storage.sync.get(["fcBlockEnabled"]);
+  const result = await api.storage.sync.get(["fcBlockEnabled"]);
   const isEnabled = result.fcBlockEnabled !== false; // Default to true
 
   // Update UI
@@ -65,34 +68,29 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function applyStateChange(newState) {
     // Save state
-    await chrome.storage.sync.set({ fcBlockEnabled: newState });
+    await api.storage.sync.set({ fcBlockEnabled: newState });
 
     // Update UI
     updateToggleState(newState);
 
     // Notify content script of state change
     try {
-      const [tab] = await chrome.tabs.query({
+      const [tab] = await api.tabs.query({
         active: true,
         currentWindow: true,
       });
       if (tab.url && tab.url.includes("farcaster.xyz")) {
-        chrome.tabs.sendMessage(
-          tab.id,
-          {
+        try {
+          const response = await api.tabs.sendMessage(tab.id, {
             action: "toggleBlock",
             enabled: newState,
-          },
-          (response) => {
-            if (chrome.runtime.lastError) {
-              console.log("Error sending message:", chrome.runtime.lastError);
-              // If content script isn't ready, reload the tab
-              chrome.tabs.reload(tab.id);
-            } else {
-              console.log("Message sent successfully:", response);
-            }
-          }
-        );
+          });
+          console.log("Message sent successfully:", response);
+        } catch (error) {
+          // Content script isn't ready — reload the tab so it re-injects.
+          console.log("Error sending message:", error);
+          api.tabs.reload(tab.id);
+        }
       }
     } catch (error) {
       console.log("Could not send message to content script:", error);


### PR DESCRIPTION
Make FC Tweak installable as a Firefox add-on alongside the Chrome build
from a single shared manifest:

- manifest.json: add browser_specific_settings.gecko (add-on ID,
  strict_min_version, data_collection_permissions: none)
- content.js / popup.js: use a dependency-free `browser ?? chrome` shim
  and normalize storage/sendMessage calls to promise style, since
  Firefox's chrome.* alias is callback-only
- release.yml: also publish fc-tweak-firefox.zip
- README: document Firefox install

Passes `web-ext lint` with 0 errors/warnings.

## Testing
ensured this still functions as expected in chrome
and works now in firefox after loading the extension manually
from local fs.
